### PR TITLE
Add appliance cycle integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
-# homeassistant-appliance-monitor
-A Home Assistant custom integration for detecting and tracking appliance cycles (washing machine, dryer, dishwasher) using a power meter and optional door sensor. Provides states, run time, last runtime, finished timestamp, and a smart status sensor that shows running time while active and the finished time until the door is opened.
+# Appliance Cycle
+
+Home Assistant custom integration for detecting and tracking appliance cycles (washing machine, dryer, dishwasher) using a power or energy sensor and an optional door sensor. The integration exposes a running binary sensor and helper sensors with run time, last runtime and finished timestamp, plus a friendly status display.
+
+## Installation
+
+### HACS (Recommended)
+
+1. Ensure [HACS](https://hacs.xyz/) is installed in your Home Assistant instance.
+2. Add this repository as a custom repository in HACS.
+3. Search for **Appliance Cycle** and install.
+4. Restart Home Assistant.
+
+### Manual
+
+1. Copy the `custom_components/appliance_cycle` folder to your Home Assistant `custom_components` directory.
+2. Restart Home Assistant.
+
+## Configuration
+
+Use the Home Assistant UI to add **Appliance Cycle** from the integration menu. You will be asked for:
+
+* Appliance type (washer, dryer or dishwasher)
+* Power or energy sensor entity
+* Optional door sensor
+
+Default detection thresholds are applied for each appliance type and can be adjusted later in the integration options.
+
+## Provided Entities
+
+* `binary_sensor.<name>_running`
+* `sensor.<name>_run_time`
+* `sensor.<name>_last_runtime`
+* `sensor.<name>_finished_at`
+* `sensor.<name>_status`
+
+## Development
+
+This repository follows [semantic versioning](https://semver.org/). Pull requests and issues are welcome!

--- a/custom_components/appliance_cycle/__init__.py
+++ b/custom_components/appliance_cycle/__init__.py
@@ -1,0 +1,38 @@
+"""Appliance cycle integration."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.const import Platform
+
+from .const import DOMAIN
+from .manager import ApplianceCycleManager
+
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
+
+
+def _get_entry_data(
+    hass: HomeAssistant, entry_id: str
+) -> ApplianceCycleManager:
+    return hass.data[DOMAIN][entry_id]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up integration from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    manager = ApplianceCycleManager(hass, entry)
+    await manager.async_setup()
+    hass.data[DOMAIN][entry.entry_id] = manager
+    await hass.config_entries.async_forward_entry_setups(
+        entry, PLATFORMS
+    )
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    manager: ApplianceCycleManager = hass.data[DOMAIN].pop(entry.entry_id)
+    await manager.async_unload()
+    return True

--- a/custom_components/appliance_cycle/binary_sensor.py
+++ b/custom_components/appliance_cycle/binary_sensor.py
@@ -1,0 +1,56 @@
+"""Binary sensors for appliance cycle."""
+
+from __future__ import annotations
+
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.const import DEVICE_CLASS_RUNNING
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from . import _get_entry_data
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    manager = _get_entry_data(hass, entry.entry_id)
+    async_add_entities([ApplianceRunningBinarySensor(manager)])
+
+
+class ApplianceRunningBinarySensor(BinarySensorEntity):
+    """Indicates if the appliance is running."""
+
+    def __init__(self, manager) -> None:
+        self.manager = manager
+        self._attr_name = f"{manager.name} Running"
+        self._attr_unique_id = f"{manager.entry.entry_id}_running"
+        self._attr_device_class = DEVICE_CLASS_RUNNING
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self.manager.update_signal,
+                self.async_write_ha_state,
+            )
+        )
+
+    @property
+    def is_on(self) -> bool:
+        return self.manager.state == "running"
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        return {
+            "appliance_type": self.manager.appliance_type,
+            "started_at": (
+                self.manager.started_at.isoformat()
+                if self.manager.started_at
+                else None
+            ),
+            "finished_at": (
+                self.manager.finished_at.isoformat()
+                if self.manager.finished_at
+                else None
+            ),
+            "run_time_seconds": self.manager.run_time_seconds,
+            "last_runtime_seconds": self.manager.last_runtime_seconds,
+        }

--- a/custom_components/appliance_cycle/config_flow.py
+++ b/custom_components/appliance_cycle/config_flow.py
@@ -1,0 +1,90 @@
+"""Config flow for appliance cycle."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import callback
+from homeassistant.helpers.selector import selector
+
+from .const import (
+    APPLIANCE_TYPES,
+    CONF_APPLIANCE_TYPE,
+    CONF_DOOR_SENSOR,
+    CONF_POWER_SENSOR,
+    DEFAULT_PROFILES,
+    DOMAIN,
+)
+
+
+class ApplianceCycleConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        if user_input is not None:
+            profile = DEFAULT_PROFILES[user_input[CONF_APPLIANCE_TYPE]].copy()
+            data = {
+                CONF_APPLIANCE_TYPE: user_input[CONF_APPLIANCE_TYPE],
+                CONF_POWER_SENSOR: user_input[CONF_POWER_SENSOR],
+                CONF_DOOR_SENSOR: user_input.get(CONF_DOOR_SENSOR),
+                "profile": profile,
+            }
+            title = user_input["name"]
+            return self.async_create_entry(title=title, data=data)
+
+        schema = vol.Schema(
+            {
+                vol.Required("name"): str,
+                vol.Required(CONF_APPLIANCE_TYPE): vol.In(APPLIANCE_TYPES),
+                vol.Required(CONF_POWER_SENSOR): selector(
+                    {"entity": {"domain": ["sensor"]}}
+                ),
+                vol.Optional(CONF_DOOR_SENSOR): selector(
+                    {"entity": {"domain": ["binary_sensor"]}}
+                ),
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=schema)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        return OptionsFlowHandler(config_entry)
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Options for Appliance Cycle."""
+
+    def __init__(self, config_entry):
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        if user_input is not None:
+            self.config_entry.data["profile"].update(user_input)
+            return self.async_create_entry(title="", data={})
+        profile = self.config_entry.data.get("profile", {})
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    "on_threshold", default=profile.get("on_threshold")
+                ): float,
+                vol.Required(
+                    "off_threshold", default=profile.get("off_threshold")
+                ): float,
+                vol.Required("delay_on", default=profile.get("delay_on")): int,
+                vol.Required(
+                    "delay_off", default=profile.get("delay_off")
+                ): int,
+                vol.Required(
+                    "quiet_end", default=profile.get("quiet_end")
+                ): int,
+                vol.Required("min_run", default=profile.get("min_run")): int,
+                vol.Required(
+                    "resume_grace", default=profile.get("resume_grace")
+                ): int,
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/appliance_cycle/const.py
+++ b/custom_components/appliance_cycle/const.py
@@ -1,0 +1,41 @@
+"""Constants for appliance_cycle integration."""
+
+from __future__ import annotations
+
+DOMAIN = "appliance_cycle"
+
+CONF_POWER_SENSOR = "power_sensor"
+CONF_DOOR_SENSOR = "door_sensor"
+CONF_APPLIANCE_TYPE = "appliance_type"
+
+APPLIANCE_TYPES = ["washer", "dryer", "dishwasher"]
+
+DEFAULT_PROFILES = {
+    "washer": {
+        "on_threshold": 15.0,
+        "off_threshold": 8.0,
+        "delay_on": 90,
+        "delay_off": 300,
+        "quiet_end": 120,
+        "min_run": 300,
+        "resume_grace": 180,
+    },
+    "dryer": {
+        "on_threshold": 80.0,
+        "off_threshold": 25.0,
+        "delay_on": 60,
+        "delay_off": 180,
+        "quiet_end": 90,
+        "min_run": 240,
+        "resume_grace": 180,
+    },
+    "dishwasher": {
+        "on_threshold": 20.0,
+        "off_threshold": 8.0,
+        "delay_on": 120,
+        "delay_off": 420,
+        "quiet_end": 180,
+        "min_run": 600,
+        "resume_grace": 240,
+    },
+}

--- a/custom_components/appliance_cycle/manager.py
+++ b/custom_components/appliance_cycle/manager.py
@@ -1,0 +1,193 @@
+"""Appliance cycle state manager."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from homeassistant.const import STATE_ON
+from homeassistant.core import HomeAssistant, callback, Event, State
+from homeassistant.helpers.event import (
+    async_call_later,
+    async_track_state_change_event,
+    async_track_time_interval,
+)
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.util.dt import utcnow
+
+from .const import (
+    CONF_APPLIANCE_TYPE,
+    CONF_DOOR_SENSOR,
+    CONF_POWER_SENSOR,
+    DEFAULT_PROFILES,
+    DOMAIN,
+)
+
+
+class ApplianceCycleManager:
+    """Class handling state machine for one appliance."""
+
+    def __init__(self, hass: HomeAssistant, entry) -> None:
+        self.hass = hass
+        self.entry = entry
+        data = entry.data
+        self.name: str = entry.title
+        self.appliance_type: str = data[CONF_APPLIANCE_TYPE]
+        self.power_entity: str = data[CONF_POWER_SENSOR]
+        self.door_entity: str | None = data.get(CONF_DOOR_SENSOR)
+        self.profile = data.get(
+            "profile", DEFAULT_PROFILES[self.appliance_type]
+        )
+
+        self.state: str = "idle"
+        self.started_at: datetime | None = None
+        self.finished_at: datetime | None = None
+        self.last_runtime: float | None = None
+
+        self._on_timer = None
+        self._off_timer = None
+        self._ticker_unsub = None
+        self._power_unsub = None
+        self._door_unsub = None
+
+        self.update_signal = f"{DOMAIN}_{entry.entry_id}_update"
+
+    async def async_setup(self) -> None:
+        """Set up listeners."""
+        self._power_unsub = async_track_state_change_event(
+            self.hass, [self.power_entity], self._power_changed
+        )
+        if self.door_entity:
+            self._door_unsub = async_track_state_change_event(
+                self.hass, [self.door_entity], self._door_changed
+            )
+        self._ticker_unsub = async_track_time_interval(
+            self.hass, self._handle_tick, timedelta(seconds=60)
+        )
+
+    async def async_unload(self) -> None:
+        """Remove listeners."""
+        if self._power_unsub:
+            self._power_unsub()
+        if self._door_unsub:
+            self._door_unsub()
+        if self._ticker_unsub:
+            self._ticker_unsub()
+        if self._on_timer:
+            self._on_timer()
+        if self._off_timer:
+            self._off_timer()
+
+    @callback
+    def _schedule_update(self) -> None:
+        async_dispatcher_send(self.hass, self.update_signal)
+
+    @callback
+    def _power_changed(self, event: Event) -> None:
+        new_state: State | None = event.data.get("new_state")
+        if new_state is None or new_state.state in ("unknown", "unavailable"):
+            return
+        try:
+            power = float(new_state.state)
+        except (ValueError, TypeError):
+            return
+
+        if self.state == "idle" and power >= self.profile["on_threshold"]:
+            if not self._on_timer:
+                self._on_timer = async_call_later(
+                    self.hass, self.profile["delay_on"], self._confirm_running
+                )
+        else:
+            if self._on_timer and power < self.profile["on_threshold"]:
+                self._on_timer()
+                self._on_timer = None
+
+        if self.state == "running" and power <= self.profile["off_threshold"]:
+            if not self._off_timer:
+                delay = self.profile["delay_off"] + self.profile["quiet_end"]
+                self._off_timer = async_call_later(
+                    self.hass, delay, self._confirm_finished
+                )
+        else:
+            if self._off_timer and power > self.profile["off_threshold"]:
+                self._off_timer()
+                self._off_timer = None
+
+    @callback
+    def _door_changed(self, event: Event) -> None:
+        if self.state != "finished":
+            return
+        new_state: State | None = event.data.get("new_state")
+        if new_state and new_state.state == STATE_ON:
+            self._reset_cycle()
+
+    @callback
+    def _confirm_running(self, _now: datetime) -> None:
+        self._on_timer = None
+        power_state = self.hass.states.get(self.power_entity)
+        if not power_state:
+            return
+        try:
+            power = float(power_state.state)
+        except (ValueError, TypeError):
+            return
+        if power < self.profile["on_threshold"]:
+            return
+        self.state = "running"
+        self.started_at = utcnow()
+        self._schedule_update()
+
+    @callback
+    def _confirm_finished(self, _now: datetime) -> None:
+        self._off_timer = None
+        power_state = self.hass.states.get(self.power_entity)
+        if not power_state:
+            return
+        try:
+            power = float(power_state.state)
+        except (ValueError, TypeError):
+            return
+        if power > self.profile["off_threshold"]:
+            return
+        if self.started_at is None:
+            return
+        runtime = (utcnow() - self.started_at).total_seconds()
+        if runtime < self.profile["min_run"]:
+            self._reset_cycle()
+            return
+        self.state = "finished"
+        self.finished_at = utcnow()
+        self.last_runtime = runtime
+        if not self.door_entity:
+            async_call_later(
+                self.hass, self.profile["resume_grace"], self._reset_cycle
+            )
+        self._schedule_update()
+
+    @callback
+    def _handle_tick(self, now: datetime) -> None:
+        if self.state == "running":
+            self._schedule_update()
+
+    @callback
+    def _reset_cycle(self, *_args) -> None:
+        self.state = "idle"
+        self.started_at = None
+        self.finished_at = None
+        self._schedule_update()
+
+    # Properties used by entities
+    @property
+    def run_time_seconds(self) -> float:
+        if self.state == "running" and self.started_at:
+            return (utcnow() - self.started_at).total_seconds()
+        return 0.0
+
+    @property
+    def last_runtime_seconds(self) -> float | None:
+        return self.last_runtime
+
+    @property
+    def finished_at_iso(self) -> str | None:
+        if self.finished_at:
+            return self.finished_at.isoformat()
+        return None

--- a/custom_components/appliance_cycle/manifest.json
+++ b/custom_components/appliance_cycle/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "appliance_cycle",
+  "name": "Appliance Cycle",
+  "version": "0.1.0",
+  "documentation": "https://github.com/example/homeassistant-appliance-monitor",
+  "requirements": [],
+  "dependencies": [],
+  "codeowners": ["@openai-labs"],
+  "config_flow": true,
+  "iot_class": "local_push"
+}

--- a/custom_components/appliance_cycle/sensor.py
+++ b/custom_components/appliance_cycle/sensor.py
@@ -1,0 +1,104 @@
+"""Sensors for appliance cycle."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import (
+    DEVICE_CLASS_DURATION,
+    DEVICE_CLASS_TIMESTAMP,
+)
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from . import _get_entry_data
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    manager = _get_entry_data(hass, entry.entry_id)
+    sensors = [
+        ApplianceRunTimeSensor(manager),
+        ApplianceLastRuntimeSensor(manager),
+        ApplianceFinishedAtSensor(manager),
+        ApplianceStatusSensor(manager),
+    ]
+    async_add_entities(sensors)
+
+
+class ApplianceBaseSensor(SensorEntity):
+    def __init__(self, manager) -> None:
+        self.manager = manager
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self.manager.update_signal,
+                self.async_write_ha_state,
+            )
+        )
+
+
+class ApplianceRunTimeSensor(ApplianceBaseSensor):
+    _attr_native_unit_of_measurement = "s"
+    _attr_device_class = DEVICE_CLASS_DURATION
+
+    def __init__(self, manager) -> None:
+        super().__init__(manager)
+        self._attr_name = f"{manager.name} Run Time"
+        self._attr_unique_id = f"{manager.entry.entry_id}_run_time"
+
+    @property
+    def native_value(self):
+        return int(self.manager.run_time_seconds)
+
+
+class ApplianceLastRuntimeSensor(ApplianceBaseSensor):
+    _attr_native_unit_of_measurement = "s"
+    _attr_device_class = DEVICE_CLASS_DURATION
+
+    def __init__(self, manager) -> None:
+        super().__init__(manager)
+        self._attr_name = f"{manager.name} Last Runtime"
+        self._attr_unique_id = f"{manager.entry.entry_id}_last_runtime"
+
+    @property
+    def native_value(self):
+        return int(self.manager.last_runtime_seconds or 0)
+
+
+class ApplianceFinishedAtSensor(ApplianceBaseSensor):
+    _attr_device_class = DEVICE_CLASS_TIMESTAMP
+
+    def __init__(self, manager) -> None:
+        super().__init__(manager)
+        self._attr_name = f"{manager.name} Finished At"
+        self._attr_unique_id = f"{manager.entry.entry_id}_finished_at"
+
+    @property
+    def native_value(self):
+        if self.manager.finished_at_iso:
+            return datetime.fromisoformat(self.manager.finished_at_iso)
+        return None
+
+
+class ApplianceStatusSensor(ApplianceBaseSensor):
+    def __init__(self, manager) -> None:
+        super().__init__(manager)
+        self._attr_name = f"{manager.name} Status"
+        self._attr_unique_id = f"{manager.entry.entry_id}_status"
+
+    @property
+    def native_value(self):
+        state = self.manager.state
+        if state == "running":
+            seconds = int(self.manager.run_time_seconds)
+            mins, secs = divmod(seconds, 60)
+            hours, mins = divmod(mins, 60)
+            if hours:
+                return f"{hours}h {mins:02d}m"
+            return f"{mins}m"
+        if state == "finished" and self.manager.finished_at:
+            return self.manager.finished_at.strftime("Finished at %H:%M")
+        return "Idle"

--- a/custom_components/appliance_cycle/translations/en.json
+++ b/custom_components/appliance_cycle/translations/en.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Appliance",
+        "description": "Configure an appliance",
+        "data": {
+          "name": "Name",
+          "appliance_type": "Appliance type",
+          "power_sensor": "Power sensor",
+          "door_sensor": "Door sensor"
+        }
+      }
+    }
+  }
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+  "name": "Appliance Cycle",
+  "country": ["all"],
+  "domains": ["appliance_cycle"],
+  "homeassistant": "2023.0.0"
+}


### PR DESCRIPTION
## Summary
- implement `appliance_cycle` custom integration for detecting appliance run cycles
- expose running, runtime, last runtime, finished timestamp and status sensors
- add HACS metadata and documentation

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c55b46e7e08326b8d698b9742baca5