### PR TITLE
fix: use modern binary sensor device class

### DIFF
--- a/custom_components/appliance_cycle/binary_sensor.py
+++ b/custom_components/appliance_cycle/binary_sensor.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.const import DEVICE_CLASS_RUNNING
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import _get_entry_data
@@ -21,7 +23,7 @@ class ApplianceRunningBinarySensor(BinarySensorEntity):
         self.manager = manager
         self._attr_name = f"{manager.name} Running"
         self._attr_unique_id = f"{manager.entry.entry_id}_running"
-        self._attr_device_class = DEVICE_CLASS_RUNNING
+        self._attr_device_class = BinarySensorDeviceClass.RUNNING
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()


### PR DESCRIPTION
## Summary
- replace deprecated `DEVICE_CLASS_RUNNING` with `BinarySensorDeviceClass.RUNNING`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7358d8ec88326b1adf3a303568211