### PR TITLE
Update status reporting and finished timestamp handling

### DIFF
--- a/custom_components/appliance_cycle/manager.py
+++ b/custom_components/appliance_cycle/manager.py
@@ -174,6 +174,7 @@ class ApplianceCycleManager:
         power = self._power_to_w(power_state)
         if power is None or power < self.profile["on_threshold"]:
             return
+        self.finished_at = None
         self.state = "running"
         self.started_at = utcnow()
         self._schedule_update()
@@ -211,7 +212,6 @@ class ApplianceCycleManager:
     def _reset_cycle(self, *_args) -> None:
         self.state = "idle"
         self.started_at = None
-        self.finished_at = None
         self._schedule_update()
 
     # Properties used by entities

--- a/custom_components/appliance_cycle/sensor.py
+++ b/custom_components/appliance_cycle/sensor.py
@@ -88,6 +88,8 @@ class ApplianceStatusSensor(ApplianceBaseSensor):
     @property
     def native_value(self):
         state = self.manager.state
+        if self.manager.door_open:
+            return "Open"
         if state == "running":
             seconds = int(self.manager.run_time_seconds)
             mins, secs = divmod(seconds, 60)
@@ -95,6 +97,6 @@ class ApplianceStatusSensor(ApplianceBaseSensor):
             if hours:
                 return f"{hours}h {mins:02d}m"
             return f"{mins}m"
-        if state == "finished" and self.manager.finished_at:
-            return self.manager.finished_at.strftime("Finished at %H:%M")
+        if state == "finished":
+            return "Finished"
         return "Idle"


### PR DESCRIPTION
## Summary
- adjust the status sensor to report "Finished" without a timestamp and show "Open" when the door is open
- clear the stored finished timestamp only when a new run starts so the Finished At sensor keeps its value until then

## Testing
- python -m compileall custom_components/appliance_cycle

------
https://chatgpt.com/codex/tasks/task_e_68c842b87524832697bc313527085cd5