### PR TITLE
Trigger release workflow after PR merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,22 @@
 name: Release
 
 on:
-  push:
+  pull_request_target:
     branches:
-      - master
+      - main
+    types:
+      - closed
 
 jobs:
   release:
-    if: github.actor != 'github-actions[bot]'
+    if: github.actor != 'github-actions[bot]' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Determine next version
         id: next_version
@@ -81,5 +84,5 @@ jobs:
         with:
           tag_name: ${{ steps.next_version.outputs.tag }}
           release_name: ${{ steps.next_version.outputs.tag }}
-          target_commitish: master
+          target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
           generate_release_notes: true


### PR DESCRIPTION
## Summary
- trigger the release workflow when pull requests into `main` are closed and merged
- ensure the workflow checks out the base branch for manifest updates and targets the merge commit for releases

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68c84e491d9c8326bf576d99da7dfb33