### PR TITLE
Add device info for appliance cycle entities

### DIFF
--- a/custom_components/appliance_cycle/binary_sensor.py
+++ b/custom_components/appliance_cycle/binary_sensor.py
@@ -19,14 +19,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities(sensors)
 
 
-class ApplianceRunningBinarySensor(BinarySensorEntity):
-    """Indicates if the appliance is running."""
-
+class ApplianceBaseBinarySensor(BinarySensorEntity):
     def __init__(self, manager) -> None:
         self.manager = manager
-        self._attr_name = f"{manager.name} Running"
-        self._attr_unique_id = f"{manager.entry.entry_id}_running"
-        self._attr_device_class = BinarySensorDeviceClass.RUNNING
+        self._attr_device_info = manager.device_info
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
@@ -37,6 +33,16 @@ class ApplianceRunningBinarySensor(BinarySensorEntity):
                 self.async_write_ha_state,
             )
         )
+
+
+class ApplianceRunningBinarySensor(ApplianceBaseBinarySensor):
+    """Indicates if the appliance is running."""
+
+    def __init__(self, manager) -> None:
+        super().__init__(manager)
+        self._attr_name = f"{manager.name} Running"
+        self._attr_unique_id = f"{manager.entry.entry_id}_running"
+        self._attr_device_class = BinarySensorDeviceClass.RUNNING
 
     @property
     def is_on(self) -> bool:
@@ -61,24 +67,14 @@ class ApplianceRunningBinarySensor(BinarySensorEntity):
         }
 
 
-class ApplianceDoorBinarySensor(BinarySensorEntity):
+class ApplianceDoorBinarySensor(ApplianceBaseBinarySensor):
     """Indicates if the appliance door is open."""
 
     def __init__(self, manager) -> None:
-        self.manager = manager
+        super().__init__(manager)
         self._attr_name = f"{manager.name} Door"
         self._attr_unique_id = f"{manager.entry.entry_id}_door"
         self._attr_device_class = BinarySensorDeviceClass.DOOR
-
-    async def async_added_to_hass(self) -> None:
-        await super().async_added_to_hass()
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                self.manager.update_signal,
-                self.async_write_ha_state,
-            )
-        )
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/appliance_cycle/manager.py
+++ b/custom_components/appliance_cycle/manager.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.event import (
     async_track_time_interval,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.util.dt import utcnow
 
 from .const import (
@@ -52,6 +53,12 @@ class ApplianceCycleManager:
         self._door_unsub = None
 
         self.update_signal = f"{DOMAIN}_{entry.entry_id}_update"
+        self._device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name=self.name,
+            manufacturer="Appliance Cycle",
+            model=self.appliance_type.title(),
+        )
 
     async def async_setup(self) -> None:
         """Set up listeners."""
@@ -252,3 +259,7 @@ class ApplianceCycleManager:
         if self.door_last_opened and self.door_last_opened >= self.finished_at:
             return 0.0
         return (utcnow() - self.finished_at).total_seconds()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return self._device_info

--- a/custom_components/appliance_cycle/sensor.py
+++ b/custom_components/appliance_cycle/sensor.py
@@ -25,6 +25,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class ApplianceBaseSensor(SensorEntity):
     def __init__(self, manager) -> None:
         self.manager = manager
+        self._attr_device_info = manager.device_info
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()


### PR DESCRIPTION
## Summary
- create a shared device definition for appliance cycle config entries
- attach device information to all binary sensors and sensors so they appear under the device

## Testing
- python -m compileall custom_components/appliance_cycle

------
https://chatgpt.com/codex/tasks/task_e_68c86762af948326b4c8f6a3179fa0ae