### PR TITLE
Update OptionsFlow for Home Assistant 2025.12 compatibility

### DIFF
--- a/custom_components/appliance_cycle/config_flow.py
+++ b/custom_components/appliance_cycle/config_flow.py
@@ -52,14 +52,11 @@ class ApplianceCycleConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Options for Appliance Cycle."""
-
-    def __init__(self, config_entry):
-        self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         if user_input is not None:

--- a/custom_components/appliance_cycle/manifest.json
+++ b/custom_components/appliance_cycle/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "appliance_cycle",
   "name": "Appliance Cycle",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "documentation": "https://github.com/example/homeassistant-appliance-monitor",
   "requirements": [],
   "dependencies": [],
@@ -9,5 +9,6 @@
     "@openai-labs"
   ],
   "config_flow": true,
-  "iot_class": "local_push"
+  "iot_class": "local_push",
+  "homeassistant": "2025.12.0"
 }


### PR DESCRIPTION
Home Assistant 2025.12 introduced breaking changes to OptionsFlow where config_entry is now automatically provided by the framework as a property.

See https://developers.home-assistant.io/blog/2024/11/12/options-flow/

Changes:
- Remove config_entry parameter from OptionsFlowHandler constructor
- Remove manual config_entry assignment
- Update manifest to require homeassistant >= 2025.12.0
- Bump version to 0.0.13