### PR TITLE
Fix options flow profile handling

### DIFF
--- a/custom_components/appliance_cycle/config_flow.py
+++ b/custom_components/appliance_cycle/config_flow.py
@@ -63,12 +63,18 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_init(self, user_input=None):
         if user_input is not None:
-            self.config_entry.data["profile"].update(user_input)
-            return self.async_create_entry(title="", data={})
+            profile = DEFAULT_PROFILES[
+                self.config_entry.data[CONF_APPLIANCE_TYPE]
+            ].copy()
+            profile.update(self.config_entry.data.get("profile", {}))
+            profile.update(self.config_entry.options.get("profile", {}))
+            profile.update(user_input)
+            return self.async_create_entry(title="", data={"profile": profile})
         profile = DEFAULT_PROFILES[
             self.config_entry.data[CONF_APPLIANCE_TYPE]
         ].copy()
         profile.update(self.config_entry.data.get("profile", {}))
+        profile.update(self.config_entry.options.get("profile", {}))
         schema = vol.Schema(
             {
                 vol.Required(

--- a/custom_components/appliance_cycle/manager.py
+++ b/custom_components/appliance_cycle/manager.py
@@ -35,14 +35,14 @@ class ApplianceCycleManager:
         self.appliance_type: str = data[CONF_APPLIANCE_TYPE]
         self.power_entity: str = data[CONF_POWER_SENSOR]
         self.door_entity: str | None = data.get(CONF_DOOR_SENSOR)
-        defaults = DEFAULT_PROFILES[self.appliance_type].copy()
+        profile = DEFAULT_PROFILES[self.appliance_type].copy()
         stored_profile = data.get("profile")
         if isinstance(stored_profile, dict):
-            for key, value in defaults.items():
-                stored_profile.setdefault(key, value)
-            self.profile = stored_profile
-        else:
-            self.profile = defaults
+            profile.update(stored_profile)
+        options_profile = entry.options.get("profile")
+        if isinstance(options_profile, dict):
+            profile.update(options_profile)
+        self.profile = profile
 
         self.state: str = "idle"
         self.started_at: datetime | None = None


### PR DESCRIPTION
### Motivation
- Opening the options (gear) UI produced a 500 because the options flow mutated `config_entry.data` and did not consider previously saved options when building the profile. 
- The intent is to avoid mutating stored entry data during options editing and to ensure option overrides are honored when rendering and applying profile values. 

### Description
- In `OptionsFlowHandler.async_step_init` the merged profile is now built from `DEFAULT_PROFILES`, `config_entry.data.get('profile')`, `config_entry.options.get('profile')`, and the `user_input`, and the options entry is saved as `{"profile": profile}` instead of mutating `config_entry.data`. 
- The options form defaults now include values from `config_entry.options.get('profile')` so the UI shows currently saved option values when opened. 
- In `ApplianceCycleManager.__init__` the profile is similarly composed from `DEFAULT_PROFILES`, the stored data profile, and `entry.options.get('profile')` so runtime uses option overrides. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e563fc2a4832686137785676cce90)