### PR TITLE
Fix manifest documentation URL

### DIFF
--- a/custom_components/appliance_cycle/manifest.json
+++ b/custom_components/appliance_cycle/manifest.json
@@ -2,7 +2,7 @@
   "domain": "appliance_cycle",
   "name": "Appliance Cycle",
   "version": "0.0.14",
-  "documentation": "https://github.com/example/homeassistant-appliance-monitor",
+  "documentation": "https://github.com/kristoffer-tungland/homeassistant-appliance-monitor",
   "requirements": [],
   "dependencies": [],
   "codeowners": [


### PR DESCRIPTION
### Motivation
- The integration manifest referenced a placeholder documentation URL instead of the actual repository.
- This could direct users and tooling to the wrong location for documentation and source.

### Description
- Updated the `documentation` field in `custom_components/appliance_cycle/manifest.json` to `https://github.com/kristoffer-tungland/homeassistant-appliance-monitor`.
- No other fields in the manifest were modified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e721be0a483269fec9d0dd0c606c2)