### PR TITLE
Use private `_config_entry` in OptionsFlowHandler to avoid AttributeError

### DIFF
--- a/custom_components/appliance_cycle/config_flow.py
+++ b/custom_components/appliance_cycle/config_flow.py
@@ -59,22 +59,22 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     """Options for Appliance Cycle."""
 
     def __init__(self, config_entry):
-        self.config_entry = config_entry
+        self._config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         if user_input is not None:
             profile = DEFAULT_PROFILES[
-                self.config_entry.data[CONF_APPLIANCE_TYPE]
+                self._config_entry.data[CONF_APPLIANCE_TYPE]
             ].copy()
-            profile.update(self.config_entry.data.get("profile", {}))
-            profile.update(self.config_entry.options.get("profile", {}))
+            profile.update(self._config_entry.data.get("profile", {}))
+            profile.update(self._config_entry.options.get("profile", {}))
             profile.update(user_input)
             return self.async_create_entry(title="", data={"profile": profile})
         profile = DEFAULT_PROFILES[
-            self.config_entry.data[CONF_APPLIANCE_TYPE]
+            self._config_entry.data[CONF_APPLIANCE_TYPE]
         ].copy()
-        profile.update(self.config_entry.data.get("profile", {}))
-        profile.update(self.config_entry.options.get("profile", {}))
+        profile.update(self._config_entry.data.get("profile", {}))
+        profile.update(self._config_entry.options.get("profile", {}))
         schema = vol.Schema(
             {
                 vol.Required(


### PR DESCRIPTION
### Motivation
- Fix an `AttributeError` raised when the options flow attempted to assign to the read-only `config_entry` property of the options flow handler.
- Ensure the options flow reads profile data from the passed config entry without writing to a reserved attribute.

### Description
- Set `self._config_entry = config_entry` in `OptionsFlowHandler.__init__` instead of assigning to `self.config_entry`.
- Replace all references to `self.config_entry` with `self._config_entry` when accessing `.data` and `.options` in `async_step_init`.
- No other behavior or schema values were changed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e8a7cc1548326984e1e49a6a2dc47)