### PR TITLE
Change duration sensors to minutes by default

### DIFF
--- a/custom_components/appliance_cycle/sensor.py
+++ b/custom_components/appliance_cycle/sensor.py
@@ -39,7 +39,7 @@ class ApplianceBaseSensor(SensorEntity):
 
 
 class ApplianceRunTimeSensor(ApplianceBaseSensor):
-    _attr_native_unit_of_measurement = "s"
+    _attr_native_unit_of_measurement = "min"
     _attr_device_class = SensorDeviceClass.DURATION
 
     def __init__(self, manager) -> None:
@@ -49,11 +49,11 @@ class ApplianceRunTimeSensor(ApplianceBaseSensor):
 
     @property
     def native_value(self):
-        return int(self.manager.run_time_seconds)
+        return self.manager.run_time_seconds / 60
 
 
 class ApplianceLastRuntimeSensor(ApplianceBaseSensor):
-    _attr_native_unit_of_measurement = "s"
+    _attr_native_unit_of_measurement = "min"
     _attr_device_class = SensorDeviceClass.DURATION
 
     def __init__(self, manager) -> None:
@@ -63,7 +63,7 @@ class ApplianceLastRuntimeSensor(ApplianceBaseSensor):
 
     @property
     def native_value(self):
-        return int(self.manager.last_runtime_seconds or 0)
+        return (self.manager.last_runtime_seconds or 0) / 60
 
 
 class ApplianceFinishedAtSensor(ApplianceBaseSensor):
@@ -82,7 +82,7 @@ class ApplianceFinishedAtSensor(ApplianceBaseSensor):
 
 
 class ApplianceTimeSinceFinishedSensor(ApplianceBaseSensor):
-    _attr_native_unit_of_measurement = "s"
+    _attr_native_unit_of_measurement = "min"
     _attr_device_class = SensorDeviceClass.DURATION
 
     def __init__(self, manager) -> None:
@@ -92,7 +92,7 @@ class ApplianceTimeSinceFinishedSensor(ApplianceBaseSensor):
 
     @property
     def native_value(self):
-        return int(self.manager.time_since_finished_seconds)
+        return self.manager.time_since_finished_seconds / 60
 
 
 class ApplianceStatusSensor(ApplianceBaseSensor):


### PR DESCRIPTION
### Motivation
- The default unit for duration sensors should be minutes instead of seconds to match expected units.
- Users expect runtime and time-since-finished values to be reported in minutes for easier reading.

### Description
- Change `_attr_native_unit_of_measurement` from `"s"` to `"min"` for `ApplianceRunTimeSensor`, `ApplianceLastRuntimeSensor`, and `ApplianceTimeSinceFinishedSensor`.
- Convert returned values from seconds to minutes by dividing the underlying `*_seconds` properties by `60` in the sensors' `native_value` properties.
- Preserve the `SensorDeviceClass.DURATION` device class for the duration sensors so Home Assistant treats them as durations.

### Testing
- No automated tests were executed for this change.
- The repository commit updated `custom_components/appliance_cycle/sensor.py` and the change was committed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f461a009083269afe7bea59fb3ed5)