### PR TITLE
Move runtime attributes to status sensor and remove time_since_finished sensor

### DIFF
--- a/custom_components/appliance_cycle/binary_sensor.py
+++ b/custom_components/appliance_cycle/binary_sensor.py
@@ -48,24 +48,6 @@ class ApplianceRunningBinarySensor(ApplianceBaseBinarySensor):
     def is_on(self) -> bool:
         return self.manager.state == "running"
 
-    @property
-    def extra_state_attributes(self) -> dict:
-        return {
-            "appliance_type": self.manager.appliance_type,
-            "started_at": (
-                self.manager.started_at.isoformat()
-                if self.manager.started_at
-                else None
-            ),
-            "finished_at": (
-                self.manager.finished_at.isoformat()
-                if self.manager.finished_at
-                else None
-            ),
-            "run_time_seconds": self.manager.run_time_seconds,
-            "last_runtime_seconds": self.manager.last_runtime_seconds,
-        }
-
 
 class ApplianceDoorBinarySensor(ApplianceBaseBinarySensor):
     """Indicates if the appliance door is open."""

--- a/custom_components/appliance_cycle/manager.py
+++ b/custom_components/appliance_cycle/manager.py
@@ -369,12 +369,8 @@ class ApplianceCycleManager:
         return None
 
     @property
-    def time_since_finished_seconds(self) -> float:
-        if not self.finished_at:
-            return 0.0
-        if self.door_last_opened and self.door_last_opened >= self.finished_at:
-            return 0.0
-        return (utcnow() - self.finished_at).total_seconds()
+    def is_starting(self) -> bool:
+        return self.state == "idle" and self._start_candidate_started is not None
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/appliance_cycle/sensor.py
+++ b/custom_components/appliance_cycle/sensor.py
@@ -16,7 +16,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
         ApplianceRunTimeSensor(manager),
         ApplianceLastRuntimeSensor(manager),
         ApplianceFinishedAtSensor(manager),
-        ApplianceTimeSinceFinishedSensor(manager),
         ApplianceStatusSensor(manager),
     ]
     async_add_entities(sensors)
@@ -81,20 +80,6 @@ class ApplianceFinishedAtSensor(ApplianceBaseSensor):
         return None
 
 
-class ApplianceTimeSinceFinishedSensor(ApplianceBaseSensor):
-    _attr_native_unit_of_measurement = "s"
-    _attr_device_class = SensorDeviceClass.DURATION
-
-    def __init__(self, manager) -> None:
-        super().__init__(manager)
-        self._attr_name = f"{manager.name} Time Since Finished"
-        self._attr_unique_id = f"{manager.entry.entry_id}_time_since_finished"
-
-    @property
-    def native_value(self):
-        return int(self.manager.time_since_finished_seconds)
-
-
 class ApplianceStatusSensor(ApplianceBaseSensor):
     def __init__(self, manager) -> None:
         super().__init__(manager)
@@ -103,16 +88,25 @@ class ApplianceStatusSensor(ApplianceBaseSensor):
 
     @property
     def native_value(self):
-        state = self.manager.state
-        if self.manager.door_open:
-            return "Open"
-        if state == "running":
-            seconds = int(self.manager.run_time_seconds)
-            mins, secs = divmod(seconds, 60)
-            hours, mins = divmod(mins, 60)
-            if hours:
-                return f"{hours}h {mins:02d}m"
-            return f"{mins}m"
-        if state == "finished":
-            return "Finished"
-        return "Idle"
+        if self.manager.is_starting:
+            return "started"
+        return self.manager.state
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        return {
+            "appliance_type": self.manager.appliance_type,
+            "started_at": (
+                self.manager.started_at.isoformat()
+                if self.manager.started_at
+                else None
+            ),
+            "finished_at": (
+                self.manager.finished_at.isoformat()
+                if self.manager.finished_at
+                else None
+            ),
+            "door_open": self.manager.door_open,
+            "run_time_seconds": self.manager.run_time_seconds,
+            "last_runtime_seconds": self.manager.last_runtime_seconds,
+        }


### PR DESCRIPTION
### Motivation
- Stop using human-readable runtime as the `status` entity state and make states canonical (`idle`, `started`, `running`, `finished`).
- Surface runtime and cycle metadata as attributes instead of embedding time text into the state.
- Remove the redundant time-since-finished sensor because the `finished_at` timestamp provides the same information.
- Consolidate cycle metadata onto the status entity rather than the running binary sensor.

### Description
- Removed the `ApplianceTimeSinceFinishedSensor` and no longer add it in `async_setup_entry`.
- Updated `ApplianceStatusSensor.native_value` to return `"started"` when `manager.is_starting` and otherwise return `manager.state`, removing formatted runtime-as-state logic.
- Added `extra_state_attributes` to `ApplianceStatusSensor` to expose `appliance_type`, `started_at`, `finished_at`, `door_open`, `run_time_seconds`, and `last_runtime_seconds`.
- Removed `extra_state_attributes` from `ApplianceRunningBinarySensor` and replaced the `time_since_finished_seconds` property on the manager with an `is_starting` property.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fc0faf78483268abc084537d4ff50)