### PR TITLE
Title-case status and add formatted runtime attribute (e.g. 1h 34m)

### DIFF
--- a/custom_components/appliance_cycle/sensor.py
+++ b/custom_components/appliance_cycle/sensor.py
@@ -89,8 +89,17 @@ class ApplianceStatusSensor(ApplianceBaseSensor):
     @property
     def native_value(self):
         if self.manager.is_starting:
-            return "started"
-        return self.manager.state
+            return "Started"
+        return self.manager.state.title()
+
+    @staticmethod
+    def _format_runtime(seconds: int | None) -> str | None:
+        if seconds is None:
+            return None
+        total_seconds = max(int(seconds), 0)
+        hours, remainder = divmod(total_seconds, 3600)
+        minutes, _ = divmod(remainder, 60)
+        return f"{hours}h {minutes}m"
 
     @property
     def extra_state_attributes(self) -> dict:
@@ -108,5 +117,6 @@ class ApplianceStatusSensor(ApplianceBaseSensor):
             ),
             "door_open": self.manager.door_open,
             "run_time_seconds": self.manager.run_time_seconds,
+            "run_time": self._format_runtime(self.manager.run_time_seconds),
             "last_runtime_seconds": self.manager.last_runtime_seconds,
         }


### PR DESCRIPTION
### Motivation
- Present the status state with a capitalized value (e.g. `Running` / `Started`) for clearer display.
- Expose a human-friendly runtime string (hours and minutes) alongside existing raw seconds attributes for easier consumption.

### Description
- Return `"Started"` when `manager.is_starting` and otherwise return `self.manager.state.title()` in `native_value` of `ApplianceStatusSensor`.
- Add a static helper ` _format_runtime(seconds: int | None) -> str | None` that converts seconds to an `"{hours}h {minutes}m"` string.
- Add a new extra state attribute `"run_time"` that uses `_format_runtime(self.manager.run_time_seconds)` alongside existing `run_time_seconds` and `last_runtime_seconds`.

### Testing
- No automated tests were run for this change.
- Change was applied to `custom_components/appliance_cycle/sensor.py` and validated via a local code edit and commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fe0e4a6988326b7833341216853f6)