### PR TITLE
Set status icon by appliance type

### DIFF
--- a/custom_components/appliance_cycle/const.py
+++ b/custom_components/appliance_cycle/const.py
@@ -10,6 +10,12 @@ CONF_APPLIANCE_TYPE = "appliance_type"
 
 APPLIANCE_TYPES = ["washer", "dryer", "dishwasher"]
 
+APPLIANCE_TYPE_ICONS = {
+    "washer": "mdi:washing-machine",
+    "dryer": "mdi:tumble-dryer",
+    "dishwasher": "mdi:dishwasher",
+}
+
 DEFAULT_PROFILES = {
     "washer": {
         "on_threshold": 15.0,

--- a/custom_components/appliance_cycle/sensor.py
+++ b/custom_components/appliance_cycle/sensor.py
@@ -8,6 +8,7 @@ from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import _get_entry_data
+from .const import APPLIANCE_TYPE_ICONS
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -85,6 +86,9 @@ class ApplianceStatusSensor(ApplianceBaseSensor):
         super().__init__(manager)
         self._attr_name = f"{manager.name} Status"
         self._attr_unique_id = f"{manager.entry.entry_id}_status"
+        self._attr_icon = APPLIANCE_TYPE_ICONS.get(
+            manager.appliance_type, "mdi:home"
+        )
 
     @property
     def native_value(self):


### PR DESCRIPTION
### Motivation

- The status entity should display an application-specific icon for better UX when monitoring appliances.
- Map known appliance types to appropriate Material Design Icons so the UI reflects the appliance role.
- Apply the configured appliance type icon to the status sensor so each integration instance shows a relevant icon.

### Description

- Added an `APPLIANCE_TYPE_ICONS` mapping in `custom_components/appliance_cycle/const.py` for `washer`, `dryer`, and `dishwasher`.
- Imported `APPLIANCE_TYPE_ICONS` in `custom_components/appliance_cycle/sensor.py` and set the icon in the `ApplianceStatusSensor` initializer.
- The status sensor now sets `self._attr_icon` from the mapping with a fallback to `mdi:home`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ff05cc4e0832699b69ba08f76727d)