### PR TITLE
Use `OptionsFlow.config_entry` in options flow and bump HA requirement to 2023.1.0

### DIFF
--- a/custom_components/appliance_cycle/config_flow.py
+++ b/custom_components/appliance_cycle/config_flow.py
@@ -52,29 +52,26 @@ class ApplianceCycleConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Options for Appliance Cycle."""
 
-    def __init__(self, config_entry):
-        self._config_entry = config_entry
-
     async def async_step_init(self, user_input=None):
         if user_input is not None:
             profile = DEFAULT_PROFILES[
-                self._config_entry.data[CONF_APPLIANCE_TYPE]
+                self.config_entry.data[CONF_APPLIANCE_TYPE]
             ].copy()
-            profile.update(self._config_entry.data.get("profile", {}))
-            profile.update(self._config_entry.options.get("profile", {}))
+            profile.update(self.config_entry.data.get("profile", {}))
+            profile.update(self.config_entry.options.get("profile", {}))
             profile.update(user_input)
             return self.async_create_entry(title="", data={"profile": profile})
         profile = DEFAULT_PROFILES[
-            self._config_entry.data[CONF_APPLIANCE_TYPE]
+            self.config_entry.data[CONF_APPLIANCE_TYPE]
         ].copy()
-        profile.update(self._config_entry.data.get("profile", {}))
-        profile.update(self._config_entry.options.get("profile", {}))
+        profile.update(self.config_entry.data.get("profile", {}))
+        profile.update(self.config_entry.options.get("profile", {}))
         schema = vol.Schema(
             {
                 vol.Required(

--- a/custom_components/appliance_cycle/manifest.json
+++ b/custom_components/appliance_cycle/manifest.json
@@ -3,6 +3,7 @@
   "name": "Appliance Cycle",
   "version": "0.0.20",
   "documentation": "https://github.com/kristoffer-tungland/homeassistant-appliance-monitor",
+  "homeassistant": "2023.1.0",
   "requirements": [],
   "dependencies": [],
   "codeowners": [

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
   "name": "Appliance Cycle",
   "country": ["all"],
   "domains": ["appliance_cycle"],
-  "homeassistant": "2023.0.0"
+  "homeassistant": "2023.1.0"
 }


### PR DESCRIPTION
### Motivation
- Update the options flow to match the new Home Assistant options flow properties that provide `config_entry` on `OptionsFlow`, avoiding manual wiring of the config entry.
- Prevent runtime warnings and compatibility issues by declaring a minimum Home Assistant version that actually provides the `config_entry` property.
- Move away from relying on `OptionsFlowWithConfigEntry` patterns and follow the current recommended options flow usage.

### Description
- Changed `async_get_options_flow` to return `OptionsFlowHandler()` instead of passing the `config_entry` argument to the handler.
- Removed the manual `__init__`-based wiring and replaced uses of `self._config_entry` with the built-in `self.config_entry` property.
- Updated `custom_components/appliance_cycle/manifest.json` and `hacs.json` to set `homeassistant` to `2023.1.0` to reflect the minimum Core version required for the new behavior.

### Testing
- Ran an automated script that scanned `homeassistant/core` `config_entries.py` across releases and confirmed `OptionsFlow.config_entry` is available starting with `2023.1.0`, and the check succeeded.
- No additional automated unit or integration tests were executed on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696024a96c588326b75d07013f0654e8)