### PR TITLE
Update integration manifest codeowners to @kristoffer-tungland

### DIFF
--- a/custom_components/appliance_cycle/manifest.json
+++ b/custom_components/appliance_cycle/manifest.json
@@ -7,7 +7,7 @@
   "requirements": [],
   "dependencies": [],
   "codeowners": [
-    "@openai-labs"
+    "@kristoffer-tungland"
   ],
   "config_flow": true,
   "iot_class": "local_push"


### PR DESCRIPTION
### Motivation
- Reassign the integration maintainership in the manifest so the `codeowners` entry points to the correct maintainer for the integration.
- Ensure the `custom_components/appliance_cycle` package metadata reflects the repository owner.

### Description
- Update the `codeowners` entry in `custom_components/appliance_cycle/manifest.json` from `@openai-labs` to `@kristoffer-tungland`.
- No other code or configuration changes were made.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696038666eb88326bd0299c9bb4bc0d4)