### PR TITLE
Add door sensor option to options flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Default detection thresholds are applied for each appliance type and can be adju
 
 ### Options
 
-All detection thresholds and timings can be tuned from the integration options dialog:
+Use the integration options dialog to update the door sensor or tune detection thresholds
+and timings:
 
 * **Delay on / Delay off / Quiet end / Minimum run / Resume grace** – control how long the integration waits to confirm that an appliance has started or finished.
 * **Start grace** – number of seconds that brief dips below the on-threshold are ignored while confirming a start, helping catch appliances that momentarily idle before the cycle fully begins.

--- a/custom_components/appliance_cycle/config_flow.py
+++ b/custom_components/appliance_cycle/config_flow.py
@@ -60,20 +60,29 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_init(self, user_input=None):
         if user_input is not None:
+            door_sensor = user_input.pop(CONF_DOOR_SENSOR, None)
             profile = DEFAULT_PROFILES[
                 self.config_entry.data[CONF_APPLIANCE_TYPE]
             ].copy()
             profile.update(self.config_entry.data.get("profile", {}))
             profile.update(self.config_entry.options.get("profile", {}))
             profile.update(user_input)
-            return self.async_create_entry(title="", data={"profile": profile})
+            return self.async_create_entry(
+                title="", data={"profile": profile, CONF_DOOR_SENSOR: door_sensor}
+            )
         profile = DEFAULT_PROFILES[
             self.config_entry.data[CONF_APPLIANCE_TYPE]
         ].copy()
         profile.update(self.config_entry.data.get("profile", {}))
         profile.update(self.config_entry.options.get("profile", {}))
+        door_sensor = self.config_entry.options.get(
+            CONF_DOOR_SENSOR, self.config_entry.data.get(CONF_DOOR_SENSOR)
+        )
         schema = vol.Schema(
             {
+                vol.Optional(CONF_DOOR_SENSOR, default=door_sensor): selector(
+                    {"entity": {"domain": ["binary_sensor"]}}
+                ),
                 vol.Required(
                     "on_threshold", default=profile.get("on_threshold")
                 ): vol.Coerce(float),

--- a/custom_components/appliance_cycle/manager.py
+++ b/custom_components/appliance_cycle/manager.py
@@ -31,10 +31,13 @@ class ApplianceCycleManager:
         self.hass = hass
         self.entry = entry
         data = entry.data
+        options = entry.options
         self.name: str = entry.title
         self.appliance_type: str = data[CONF_APPLIANCE_TYPE]
         self.power_entity: str = data[CONF_POWER_SENSOR]
-        self.door_entity: str | None = data.get(CONF_DOOR_SENSOR)
+        self.door_entity: str | None = options.get(
+            CONF_DOOR_SENSOR, data.get(CONF_DOOR_SENSOR)
+        )
         profile = DEFAULT_PROFILES[self.appliance_type].copy()
         stored_profile = data.get("profile")
         if isinstance(stored_profile, dict):

--- a/custom_components/appliance_cycle/translations/en.json
+++ b/custom_components/appliance_cycle/translations/en.json
@@ -17,6 +17,7 @@
     "step": {
       "init": {
         "data": {
+          "door_sensor": "Door sensor",
           "on_threshold": "On threshold (W)",
           "off_threshold": "Off threshold (W)",
           "delay_on": "On delay (seconds)",


### PR DESCRIPTION
### Motivation

- Allow changing the configured door sensor after an integration instance has been added by exposing it in the integration options flow.
- Ensure the manager uses the options-provided door sensor so UI changes take effect without re-adding the integration.

### Description

- Add a door sensor selector to the options form in `custom_components/appliance_cycle/config_flow.py` and prefill it with the current configured value.
- Persist the selected door sensor into the entry options as `CONF_DOOR_SENSOR` when the options form is saved.
- Update `ApplianceCycleManager` in `custom_components/appliance_cycle/manager.py` to prefer `entry.options[CONF_DOOR_SENSOR]` and fall back to `entry.data[CONF_DOOR_SENSOR]`.
- Add the `door_sensor` label to `custom_components/appliance_cycle/translations/en.json` and update `README.md` to document that the door sensor can be updated via the integration options.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967c41e48848326b1278726050e8111)