### PR TITLE
Add option to toggle door open state on closed pulses

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ and timings:
 
 * **Delay on / Delay off / Quiet end / Minimum run / Resume grace** – control how long the integration waits to confirm that an appliance has started or finished.
 * **Start grace** – number of seconds that brief dips below the on-threshold are ignored while confirming a start, helping catch appliances that momentarily idle before the cycle fully begins.
+* **Toggle door open on closed pulses** – use when a door sensor reports brief "closed" pulses while opening/closing; each closed pulse toggles between open/closed, and the door resets to closed when a cycle starts.
 
 ## Provided Entities
 

--- a/custom_components/appliance_cycle/config_flow.py
+++ b/custom_components/appliance_cycle/config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.selector import selector
 from .const import (
     APPLIANCE_TYPES,
     CONF_APPLIANCE_TYPE,
+    CONF_DOOR_CLOSED_PULSE_TOGGLES,
     CONF_DOOR_SENSOR,
     CONF_POWER_SENSOR,
     DEFAULT_PROFILES,
@@ -61,6 +62,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None):
         if user_input is not None:
             door_sensor = user_input.pop(CONF_DOOR_SENSOR, None)
+            door_closed_pulse_toggles = user_input.pop(
+                CONF_DOOR_CLOSED_PULSE_TOGGLES, False
+            )
             profile = DEFAULT_PROFILES[
                 self.config_entry.data[CONF_APPLIANCE_TYPE]
             ].copy()
@@ -68,7 +72,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             profile.update(self.config_entry.options.get("profile", {}))
             profile.update(user_input)
             return self.async_create_entry(
-                title="", data={"profile": profile, CONF_DOOR_SENSOR: door_sensor}
+                title="",
+                data={
+                    "profile": profile,
+                    CONF_DOOR_SENSOR: door_sensor,
+                    CONF_DOOR_CLOSED_PULSE_TOGGLES: door_closed_pulse_toggles,
+                },
             )
         profile = DEFAULT_PROFILES[
             self.config_entry.data[CONF_APPLIANCE_TYPE]
@@ -78,11 +87,18 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         door_sensor = self.config_entry.options.get(
             CONF_DOOR_SENSOR, self.config_entry.data.get(CONF_DOOR_SENSOR)
         )
+        door_closed_pulse_toggles = self.config_entry.options.get(
+            CONF_DOOR_CLOSED_PULSE_TOGGLES, False
+        )
         schema = vol.Schema(
             {
                 vol.Optional(CONF_DOOR_SENSOR, default=door_sensor): selector(
                     {"entity": {"domain": ["binary_sensor"]}}
                 ),
+                vol.Required(
+                    CONF_DOOR_CLOSED_PULSE_TOGGLES,
+                    default=door_closed_pulse_toggles,
+                ): bool,
                 vol.Required(
                     "on_threshold", default=profile.get("on_threshold")
                 ): vol.Coerce(float),

--- a/custom_components/appliance_cycle/const.py
+++ b/custom_components/appliance_cycle/const.py
@@ -6,6 +6,7 @@ DOMAIN = "appliance_cycle"
 
 CONF_POWER_SENSOR = "power_sensor"
 CONF_DOOR_SENSOR = "door_sensor"
+CONF_DOOR_CLOSED_PULSE_TOGGLES = "door_closed_pulse_toggles"
 CONF_APPLIANCE_TYPE = "appliance_type"
 
 APPLIANCE_TYPES = ["washer", "dryer", "dishwasher"]

--- a/custom_components/appliance_cycle/manager.py
+++ b/custom_components/appliance_cycle/manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
-from homeassistant.const import STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, callback, Event, State
 from homeassistant.helpers.event import (
     async_call_later,
@@ -17,6 +17,7 @@ from homeassistant.util.dt import utcnow
 
 from .const import (
     CONF_APPLIANCE_TYPE,
+    CONF_DOOR_CLOSED_PULSE_TOGGLES,
     CONF_DOOR_SENSOR,
     CONF_POWER_SENSOR,
     DEFAULT_PROFILES,
@@ -37,6 +38,9 @@ class ApplianceCycleManager:
         self.power_entity: str = data[CONF_POWER_SENSOR]
         self.door_entity: str | None = options.get(
             CONF_DOOR_SENSOR, data.get(CONF_DOOR_SENSOR)
+        )
+        self.door_closed_pulse_toggles: bool = options.get(
+            CONF_DOOR_CLOSED_PULSE_TOGGLES, False
         )
         profile = DEFAULT_PROFILES[self.appliance_type].copy()
         stored_profile = data.get("profile")
@@ -86,11 +90,14 @@ class ApplianceCycleManager:
             self._door_unsub = async_track_state_change_event(
                 self.hass, [self.door_entity], self._door_changed
             )
-            door_state = self.hass.states.get(self.door_entity)
-            if door_state and door_state.state not in ("unknown", "unavailable"):
-                self.door_is_open = door_state.state == STATE_ON
-                if self.door_is_open:
-                    self.door_last_opened = door_state.last_changed
+            if self.door_closed_pulse_toggles:
+                self.door_is_open = False
+            else:
+                door_state = self.hass.states.get(self.door_entity)
+                if door_state and door_state.state not in ("unknown", "unavailable"):
+                    self.door_is_open = door_state.state == STATE_ON
+                    if self.door_is_open:
+                        self.door_last_opened = door_state.last_changed
         power_state = self.hass.states.get(self.power_entity)
         if power_state and power_state.state not in ("unknown", "unavailable"):
             power = self._power_to_w(power_state)
@@ -272,7 +279,12 @@ class ApplianceCycleManager:
         new_state: State | None = event.data.get("new_state")
         if new_state is None or new_state.state in ("unknown", "unavailable"):
             return
-        is_open = new_state.state == STATE_ON
+        if self.door_closed_pulse_toggles:
+            if new_state.state != STATE_OFF:
+                return
+            is_open = not bool(self.door_is_open)
+        else:
+            is_open = new_state.state == STATE_ON
         self.door_is_open = is_open
         if is_open:
             self.door_last_opened = utcnow()
@@ -323,6 +335,8 @@ class ApplianceCycleManager:
             self.started_at = start_time
         else:
             self.started_at = utcnow()
+        if self.door_closed_pulse_toggles and self.door_entity:
+            self.door_is_open = False
         self._energy_kwh_current = 0.0
         self._energy_sample_time = self.started_at
         self._schedule_update()

--- a/custom_components/appliance_cycle/manifest.json
+++ b/custom_components/appliance_cycle/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "appliance_cycle",
   "name": "Appliance Cycle",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "documentation": "https://github.com/kristoffer-tungland/homeassistant-appliance-monitor",
   "homeassistant": "2023.1.0",
   "requirements": [],

--- a/custom_components/appliance_cycle/translations/en.json
+++ b/custom_components/appliance_cycle/translations/en.json
@@ -18,6 +18,7 @@
       "init": {
         "data": {
           "door_sensor": "Door sensor",
+          "door_closed_pulse_toggles": "Toggle door open on closed pulses",
           "on_threshold": "On threshold (W)",
           "off_threshold": "Off threshold (W)",
           "delay_on": "On delay (seconds)",


### PR DESCRIPTION
### Motivation
- Some door sensors produce brief `closed` pulses while opening/closing when installed in sub‑optimal positions, so a toggle mode is needed to treat a `closed` pulse as an open/close transition. 
- The pulse-based door state must be reset to closed when a cycle starts to avoid getting out of sync with the appliance.

### Description
- Add a new option `CONF_DOOR_CLOSED_PULSE_TOGGLES` and expose it in the integration options UI to enable pulse toggle behavior. 
- In `ApplianceCycleManager` record `door_closed_pulse_toggles` and, when enabled, initialize `door_is_open` to `False` and interpret only `STATE_OFF` events as pulses that toggle `door_is_open`. 
- Reset the pulse-based door state to closed when a cycle is confirmed running in `_confirm_running`. 
- Update `config_flow` to persist the option and add a translation string and README documentation describing the `Toggle door open on closed pulses` option.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972abb6acb8832690116b8b7da948a0)